### PR TITLE
Add Meeting entity with CRUD endpoints

### DIFF
--- a/lawyer.api.appointment.application/Common/MappingProfiles/MeetingProfile.cs
+++ b/lawyer.api.appointment.application/Common/MappingProfiles/MeetingProfile.cs
@@ -1,0 +1,17 @@
+using AutoMapper;
+using lawyer.api.appointment.application.DTO;
+using lawyer.api.appointment.application.UseCases.Meeting.Create;
+using lawyer.api.appointment.application.UseCases.Meeting.Update;
+using lawyer.api.appointment.domain;
+
+namespace lawyer.api.appointment.application.Common.MappingProfiles;
+
+public class MeetingProfile : Profile
+{
+    public MeetingProfile()
+    {
+        CreateMap<MeetingDto, Meeting>().ReverseMap();
+        CreateMap<CreateMeetingCommand, Meeting>().ReverseMap();
+        CreateMap<UpdateMeetingCommand, Meeting>().ReverseMap();
+    }
+}

--- a/lawyer.api.appointment.application/Contracts/Interfaces/Persistence/Meeting/IMeetingCommandRepository.cs
+++ b/lawyer.api.appointment.application/Contracts/Interfaces/Persistence/Meeting/IMeetingCommandRepository.cs
@@ -1,0 +1,7 @@
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Common;
+
+namespace lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Meeting;
+
+public interface IMeetingCommandRepository : ICommandRepository<domain.Meeting>
+{
+}

--- a/lawyer.api.appointment.application/Contracts/Interfaces/Persistence/Meeting/IMeetingQueryRepository.cs
+++ b/lawyer.api.appointment.application/Contracts/Interfaces/Persistence/Meeting/IMeetingQueryRepository.cs
@@ -1,0 +1,7 @@
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Common;
+
+namespace lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Meeting;
+
+public interface IMeetingQueryRepository : IQueryRepository<domain.Meeting>
+{
+}

--- a/lawyer.api.appointment.application/DTO/MeetingDto.cs
+++ b/lawyer.api.appointment.application/DTO/MeetingDto.cs
@@ -1,0 +1,10 @@
+namespace lawyer.api.appointment.application.DTO;
+
+public class MeetingDto
+{
+    public Guid Id { get; set; }
+    public Guid IdUser { get; set; }
+    public Guid IdLawFirm { get; set; }
+    public Guid IdLead { get; set; }
+    public DateTime Date { get; set; }
+}

--- a/lawyer.api.appointment.application/UseCases/Meeting/Create/CreateMeetingCommand.cs
+++ b/lawyer.api.appointment.application/UseCases/Meeting/Create/CreateMeetingCommand.cs
@@ -1,0 +1,11 @@
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Meeting.Create;
+
+public class CreateMeetingCommand : IRequest<Guid>
+{
+    public Guid IdUser { get; set; }
+    public Guid IdLawFirm { get; set; }
+    public Guid IdLead { get; set; }
+    public DateTime Date { get; set; }
+}

--- a/lawyer.api.appointment.application/UseCases/Meeting/Create/CreateMeetingCommandHandler.cs
+++ b/lawyer.api.appointment.application/UseCases/Meeting/Create/CreateMeetingCommandHandler.cs
@@ -1,0 +1,26 @@
+using AutoMapper;
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Meeting;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Meeting.Create;
+
+public class CreateMeetingCommandHandler : IRequestHandler<CreateMeetingCommand, Guid>
+{
+    private readonly IMeetingCommandRepository _command;
+    private readonly IMapper _mapper;
+
+    public CreateMeetingCommandHandler(
+        IMeetingCommandRepository command,
+        IMapper mapper)
+    {
+        _command = command;
+        _mapper = mapper;
+    }
+
+    public async Task<Guid> Handle(CreateMeetingCommand request, CancellationToken cancellationToken)
+    {
+        var entity = _mapper.Map<domain.Meeting>(request);
+        await _command.CreateAsync(entity);
+        return entity.Id;
+    }
+}

--- a/lawyer.api.appointment.application/UseCases/Meeting/Delete/DeleteMeetingCommand.cs
+++ b/lawyer.api.appointment.application/UseCases/Meeting/Delete/DeleteMeetingCommand.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Meeting.Delete;
+
+public class DeleteMeetingCommand : IRequest<Unit>
+{
+    public Guid Id { get; set; }
+}

--- a/lawyer.api.appointment.application/UseCases/Meeting/Delete/DeleteMeetingCommandHandler.cs
+++ b/lawyer.api.appointment.application/UseCases/Meeting/Delete/DeleteMeetingCommandHandler.cs
@@ -1,0 +1,23 @@
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Meeting;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Meeting.Delete;
+
+public class DeleteMeetingCommandHandler : IRequestHandler<DeleteMeetingCommand, Unit>
+{
+    private readonly IMeetingCommandRepository _command;
+    private readonly IMeetingQueryRepository _query;
+
+    public DeleteMeetingCommandHandler(IMeetingCommandRepository command, IMeetingQueryRepository query)
+    {
+        _command = command;
+        _query = query;
+    }
+
+    public async Task<Unit> Handle(DeleteMeetingCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _query.GetByIdAsync(request.Id);
+        await _command.DeleteAsync(entity);
+        return Unit.Value;
+    }
+}

--- a/lawyer.api.appointment.application/UseCases/Meeting/GetAll/GetAllMeetingQuery.cs
+++ b/lawyer.api.appointment.application/UseCases/Meeting/GetAll/GetAllMeetingQuery.cs
@@ -1,0 +1,8 @@
+using lawyer.api.appointment.application.DTO;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Meeting.GetAll;
+
+public class GetAllMeetingQuery : IRequest<List<MeetingDto>>
+{
+}

--- a/lawyer.api.appointment.application/UseCases/Meeting/GetAll/GetAllMeetingQueryHandler.cs
+++ b/lawyer.api.appointment.application/UseCases/Meeting/GetAll/GetAllMeetingQueryHandler.cs
@@ -1,0 +1,26 @@
+using AutoMapper;
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Meeting;
+using lawyer.api.appointment.application.DTO;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Meeting.GetAll;
+
+public class GetAllMeetingQueryHandler : IRequestHandler<GetAllMeetingQuery, List<MeetingDto>>
+{
+    private readonly IMeetingQueryRepository _query;
+    private readonly IMapper _mapper;
+
+    public GetAllMeetingQueryHandler(
+        IMapper mapper,
+        IMeetingQueryRepository query)
+    {
+        _mapper = mapper;
+        _query = query;
+    }
+
+    public async Task<List<MeetingDto>> Handle(GetAllMeetingQuery request, CancellationToken cancellationToken)
+    {
+        var entities = await _query.GetAllAsync();
+        return _mapper.Map<List<MeetingDto>>(entities);
+    }
+}

--- a/lawyer.api.appointment.application/UseCases/Meeting/GetById/GetByIdMeetingQuery.cs
+++ b/lawyer.api.appointment.application/UseCases/Meeting/GetById/GetByIdMeetingQuery.cs
@@ -1,0 +1,14 @@
+using lawyer.api.appointment.application.DTO;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Meeting.GetById;
+
+public class GetByIdMeetingQuery : IRequest<MeetingDto>
+{
+    public GetByIdMeetingQuery(Guid id)
+    {
+        Id = id;
+    }
+
+    public Guid Id { get; set; }
+}

--- a/lawyer.api.appointment.application/UseCases/Meeting/GetById/GetByIdMeetingQueryHandler.cs
+++ b/lawyer.api.appointment.application/UseCases/Meeting/GetById/GetByIdMeetingQueryHandler.cs
@@ -1,0 +1,26 @@
+using AutoMapper;
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Meeting;
+using lawyer.api.appointment.application.DTO;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Meeting.GetById;
+
+public class GetByIdMeetingQueryHandler : IRequestHandler<GetByIdMeetingQuery, MeetingDto>
+{
+    private readonly IMapper _mapper;
+    private readonly IMeetingQueryRepository _query;
+
+    public GetByIdMeetingQueryHandler(
+        IMapper mapper,
+        IMeetingQueryRepository query)
+    {
+        _mapper = mapper;
+        _query = query;
+    }
+
+    public async Task<MeetingDto> Handle(GetByIdMeetingQuery request, CancellationToken cancellationToken)
+    {
+        var entity = await _query.GetByIdAsync(request.Id);
+        return _mapper.Map<MeetingDto>(entity);
+    }
+}

--- a/lawyer.api.appointment.application/UseCases/Meeting/Update/UpdateMeetingCommand.cs
+++ b/lawyer.api.appointment.application/UseCases/Meeting/Update/UpdateMeetingCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Meeting.Update;
+
+public class UpdateMeetingCommand : IRequest<Guid>
+{
+    public Guid Id { get; set; }
+    public Guid IdUser { get; set; }
+    public Guid IdLawFirm { get; set; }
+    public Guid IdLead { get; set; }
+    public DateTime Date { get; set; }
+}

--- a/lawyer.api.appointment.application/UseCases/Meeting/Update/UpdateMeetingCommandHandler.cs
+++ b/lawyer.api.appointment.application/UseCases/Meeting/Update/UpdateMeetingCommandHandler.cs
@@ -1,0 +1,33 @@
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Meeting;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Meeting.Update;
+
+public class UpdateMeetingCommandHandler : IRequestHandler<UpdateMeetingCommand, Guid>
+{
+    private readonly IMeetingCommandRepository _command;
+    private readonly IMeetingQueryRepository _query;
+
+    public UpdateMeetingCommandHandler(
+        IMeetingCommandRepository command,
+        IMeetingQueryRepository query)
+    {
+        _command = command;
+        _query = query;
+    }
+
+    public async Task<Guid> Handle(UpdateMeetingCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _query.GetByIdAsync(request.Id);
+        if (entity == null) throw new KeyNotFoundException($"The meeting with ID {request.Id} does not exist.");
+
+        entity.IdUser = request.IdUser;
+        entity.IdLawFirm = request.IdLawFirm;
+        entity.IdLead = request.IdLead;
+        entity.Date = request.Date;
+        entity.DateModified = DateTime.UtcNow;
+
+        await _command.UpdateAsync(entity);
+        return entity.Id;
+    }
+}

--- a/lawyer.api.appointment.datastore.mssql/DatabaseContext/LawyersContext.cs
+++ b/lawyer.api.appointment.datastore.mssql/DatabaseContext/LawyersContext.cs
@@ -14,6 +14,7 @@ public class LawyersContext : DbContext
     public DbSet<CityEntity> Cities { get; set; }
     public DbSet<CountryEntity> Countries { get; set; }
     public DbSet<SocialNetworkEntity> SocialNetworks { get; set; }
+    public DbSet<MeetingEntity> Meetings { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/lawyer.api.appointment.datastore.mssql/Model/MappingProfile/ApplicationMappingProfile.cs
+++ b/lawyer.api.appointment.datastore.mssql/Model/MappingProfile/ApplicationMappingProfile.cs
@@ -12,5 +12,6 @@ public class ApplicationMappingProfile : Profile
         CreateMap<City, CityEntity>().ReverseMap();
         CreateMap<Country, CountryEntity>().ReverseMap();
         CreateMap<SocialNetwork, SocialNetworkEntity>().ReverseMap();
+        CreateMap<Meeting, MeetingEntity>().ReverseMap();
     }
 }

--- a/lawyer.api.appointment.datastore.mssql/Model/Meeting.cs
+++ b/lawyer.api.appointment.datastore.mssql/Model/Meeting.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using lawyer.api.appointment.datastore.mssql.Model.Common;
+
+namespace lawyer.api.appointment.datastore.mssql.Model;
+
+[Table("Meetings", Schema = "appointments")]
+public class MeetingEntity : EFEntity
+{
+    public Guid IdUser { get; set; }
+    public Guid IdLawFirm { get; set; }
+    public Guid IdLead { get; set; }
+    public DateTime Date { get; set; }
+}

--- a/lawyer.api.appointment.datastore.mssql/PersistenceServiceRegistration.cs
+++ b/lawyer.api.appointment.datastore.mssql/PersistenceServiceRegistration.cs
@@ -2,12 +2,14 @@ using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Exampl
 using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.City;
 using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Country;
 using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.SocialNetwork;
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Meeting;
 using lawyer.api.appointment.datastore.mssql.DatabaseContext;
 using lawyer.api.appointment.datastore.mssql.Model.MappingProfile;
 using lawyer.api.appointment.datastore.mssql.Repositories.Example;
 using lawyer.api.appointment.datastore.mssql.Repositories.City;
 using lawyer.api.appointment.datastore.mssql.Repositories.Country;
 using lawyer.api.appointment.datastore.mssql.Repositories.SocialNetwork;
+using lawyer.api.appointment.datastore.mssql.Repositories.Meeting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,6 +32,8 @@ public static class PersistenceServiceRegistration
         services.AddScoped<ICountryQueryRepository, CountryQueryRepository>();
         services.AddScoped<ISocialNetworkCommandRepository, SocialNetworkCommandRepository>();
         services.AddScoped<ISocialNetworkQueryRepository, SocialNetworkQueryRepository>();
+        services.AddScoped<IMeetingCommandRepository, MeetingCommandRepository>();
+        services.AddScoped<IMeetingQueryRepository, MeetingQueryRepository>();
 
         return services;
     }

--- a/lawyer.api.appointment.datastore.mssql/Repositories/Meeting/MeetingCommandRepository.cs
+++ b/lawyer.api.appointment.datastore.mssql/Repositories/Meeting/MeetingCommandRepository.cs
@@ -1,0 +1,17 @@
+using AutoMapper;
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Meeting;
+using lawyer.api.appointment.datastore.mssql.DatabaseContext;
+using lawyer.api.appointment.datastore.mssql.Model;
+using lawyer.api.appointment.datastore.mssql.Repositories.Common;
+
+namespace lawyer.api.appointment.datastore.mssql.Repositories.Meeting;
+
+public class MeetingCommandRepository : CommandRepository<domain.Meeting, MeetingEntity>, IMeetingCommandRepository
+{
+    private readonly IMapper _mapper;
+
+    public MeetingCommandRepository(LawyersContext dbContext, IMapper mapper) : base(dbContext, mapper)
+    {
+        _mapper = mapper;
+    }
+}

--- a/lawyer.api.appointment.datastore.mssql/Repositories/Meeting/MeetingQueryRepository.cs
+++ b/lawyer.api.appointment.datastore.mssql/Repositories/Meeting/MeetingQueryRepository.cs
@@ -1,0 +1,17 @@
+using AutoMapper;
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Meeting;
+using lawyer.api.appointment.datastore.mssql.DatabaseContext;
+using lawyer.api.appointment.datastore.mssql.Model;
+using lawyer.api.appointment.datastore.mssql.Repositories.Common;
+
+namespace lawyer.api.appointment.datastore.mssql.Repositories.Meeting;
+
+public class MeetingQueryRepository : QueryRepository<domain.Meeting, MeetingEntity>, IMeetingQueryRepository
+{
+    private readonly IMapper _mapper;
+
+    public MeetingQueryRepository(LawyersContext dbContext, IMapper mapper) : base(dbContext, mapper)
+    {
+        _mapper = mapper;
+    }
+}

--- a/lawyer.api.appointment.domain/Meeting.cs
+++ b/lawyer.api.appointment.domain/Meeting.cs
@@ -1,0 +1,11 @@
+using lawyer.api.appointment.domain.Common;
+
+namespace lawyer.api.appointment.domain;
+
+public class Meeting : BaseEntity
+{
+    public Guid IdUser { get; set; }
+    public Guid IdLawFirm { get; set; }
+    public Guid IdLead { get; set; }
+    public DateTime Date { get; set; }
+}

--- a/lawyer.api.appointment.webapi/Controllers/MeetingController.cs
+++ b/lawyer.api.appointment.webapi/Controllers/MeetingController.cs
@@ -1,0 +1,70 @@
+using lawyer.api.appointment.application.DTO;
+using lawyer.api.appointment.application.UseCases.Meeting.Create;
+using lawyer.api.appointment.application.UseCases.Meeting.Delete;
+using lawyer.api.appointment.application.UseCases.Meeting.GetAll;
+using lawyer.api.appointment.application.UseCases.Meeting.GetById;
+using lawyer.api.appointment.application.UseCases.Meeting.Update;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace lawyer.api.appointment.webapi.Controllers;
+
+[Authorize]
+[ApiController]
+[Route("api/[controller]")]
+public class MeetingController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public MeetingController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<MeetingDto>>> Get()
+    {
+        var entities = await _mediator.Send(new GetAllMeetingQuery());
+        return Ok(entities);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<MeetingDto>> Get(Guid id)
+    {
+        var entity = await _mediator.Send(new GetByIdMeetingQuery(id));
+        return Ok(entity);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(201)]
+    [ProducesResponseType(400)]
+    public async Task<ActionResult> Post([FromBody] CreateMeetingCommand command)
+    {
+        var id = await _mediator.Send(command);
+        var url = Url.Action(nameof(Get), new { id });
+        return Created(url, id);
+    }
+
+    [HttpPut]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(400)]
+    public async Task<ActionResult> Put([FromBody] UpdateMeetingCommand command)
+    {
+        if (command.Id == Guid.Empty)
+            return BadRequest("The provided ID is not valid.");
+
+        var updatedId = await _mediator.Send(command);
+        return Ok(updatedId);
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(404)]
+    public async Task<ActionResult> Delete(Guid id)
+    {
+        var command = new DeleteMeetingCommand { Id = id };
+        await _mediator.Send(command);
+        return NoContent();
+    }
+}


### PR DESCRIPTION
## Summary
- add Meeting domain entity and DTO
- implement repositories, mappings, and persistence registration for Meeting
- expose Meeting CRUD commands, queries, and API controller

## Testing
- `dotnet build lawyer.api.appointment.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a35d73b083239a362c4aa6972cda