### PR TITLE
Add Payment entity and CRUD endpoints

### DIFF
--- a/lawyer.api.appointment.application/Common/MappingProfiles/PaymentProfile.cs
+++ b/lawyer.api.appointment.application/Common/MappingProfiles/PaymentProfile.cs
@@ -1,0 +1,18 @@
+using AutoMapper;
+using lawyer.api.appointment.application.DTO;
+using lawyer.api.appointment.application.UseCases.Payment.Create;
+using lawyer.api.appointment.application.UseCases.Payment.Update;
+using lawyer.api.appointment.domain;
+
+namespace lawyer.api.appointment.application.Common.MappingProfiles;
+
+public class PaymentProfile : Profile
+{
+    public PaymentProfile()
+    {
+        CreateMap<PaymentDto, Payment>().ReverseMap();
+        CreateMap<CreatePaymentCommand, Payment>().ReverseMap();
+        CreateMap<UpdatePaymentCommand, Payment>().ReverseMap();
+    }
+}
+

--- a/lawyer.api.appointment.application/Contracts/Interfaces/Persistence/Payment/IPaymentCommandRepository.cs
+++ b/lawyer.api.appointment.application/Contracts/Interfaces/Persistence/Payment/IPaymentCommandRepository.cs
@@ -1,0 +1,8 @@
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Common;
+
+namespace lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Payment;
+
+public interface IPaymentCommandRepository : ICommandRepository<domain.Payment>
+{
+}
+

--- a/lawyer.api.appointment.application/Contracts/Interfaces/Persistence/Payment/IPaymentQueryRepository.cs
+++ b/lawyer.api.appointment.application/Contracts/Interfaces/Persistence/Payment/IPaymentQueryRepository.cs
@@ -1,0 +1,8 @@
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Common;
+
+namespace lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Payment;
+
+public interface IPaymentQueryRepository : IQueryRepository<domain.Payment>
+{
+}
+

--- a/lawyer.api.appointment.application/DTO/PaymentDto.cs
+++ b/lawyer.api.appointment.application/DTO/PaymentDto.cs
@@ -1,0 +1,12 @@
+namespace lawyer.api.appointment.application.DTO;
+
+public class PaymentDto
+{
+    public Guid Id { get; set; }
+    public Guid IdUser { get; set; }
+    public Guid IdLawFirm { get; set; }
+    public Guid IdMeeting { get; set; }
+    public decimal Value { get; set; }
+    public string State { get; set; }
+}
+

--- a/lawyer.api.appointment.application/UseCases/Payment/Create/CreatePaymentCommand.cs
+++ b/lawyer.api.appointment.application/UseCases/Payment/Create/CreatePaymentCommand.cs
@@ -1,0 +1,13 @@
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Payment.Create;
+
+public class CreatePaymentCommand : IRequest<Guid>
+{
+    public Guid IdUser { get; set; }
+    public Guid IdLawFirm { get; set; }
+    public Guid IdMeeting { get; set; }
+    public decimal Value { get; set; }
+    public string State { get; set; } = string.Empty;
+}
+

--- a/lawyer.api.appointment.application/UseCases/Payment/Create/CreatePaymentCommandHandler.cs
+++ b/lawyer.api.appointment.application/UseCases/Payment/Create/CreatePaymentCommandHandler.cs
@@ -1,0 +1,27 @@
+using AutoMapper;
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Payment;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Payment.Create;
+
+public class CreatePaymentCommandHandler : IRequestHandler<CreatePaymentCommand, Guid>
+{
+    private readonly IPaymentCommandRepository _command;
+    private readonly IMapper _mapper;
+
+    public CreatePaymentCommandHandler(
+        IPaymentCommandRepository command,
+        IMapper mapper)
+    {
+        _command = command;
+        _mapper = mapper;
+    }
+
+    public async Task<Guid> Handle(CreatePaymentCommand request, CancellationToken cancellationToken)
+    {
+        var entity = _mapper.Map<domain.Payment>(request);
+        await _command.CreateAsync(entity);
+        return entity.Id;
+    }
+}
+

--- a/lawyer.api.appointment.application/UseCases/Payment/Delete/DeletePaymentCommand.cs
+++ b/lawyer.api.appointment.application/UseCases/Payment/Delete/DeletePaymentCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Payment.Delete;
+
+public class DeletePaymentCommand : IRequest<Unit>
+{
+    public Guid Id { get; set; }
+}
+

--- a/lawyer.api.appointment.application/UseCases/Payment/Delete/DeletePaymentCommandHandler.cs
+++ b/lawyer.api.appointment.application/UseCases/Payment/Delete/DeletePaymentCommandHandler.cs
@@ -1,0 +1,24 @@
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Payment;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Payment.Delete;
+
+public class DeletePaymentCommandHandler : IRequestHandler<DeletePaymentCommand, Unit>
+{
+    private readonly IPaymentCommandRepository _command;
+    private readonly IPaymentQueryRepository _query;
+
+    public DeletePaymentCommandHandler(IPaymentCommandRepository command, IPaymentQueryRepository query)
+    {
+        _command = command;
+        _query = query;
+    }
+
+    public async Task<Unit> Handle(DeletePaymentCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _query.GetByIdAsync(request.Id);
+        await _command.DeleteAsync(entity);
+        return Unit.Value;
+    }
+}
+

--- a/lawyer.api.appointment.application/UseCases/Payment/GetAll/GetAllPaymentQuery.cs
+++ b/lawyer.api.appointment.application/UseCases/Payment/GetAll/GetAllPaymentQuery.cs
@@ -1,0 +1,9 @@
+using lawyer.api.appointment.application.DTO;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Payment.GetAll;
+
+public class GetAllPaymentQuery : IRequest<List<PaymentDto>>
+{
+}
+

--- a/lawyer.api.appointment.application/UseCases/Payment/GetAll/GetAllPaymentQueryHandler.cs
+++ b/lawyer.api.appointment.application/UseCases/Payment/GetAll/GetAllPaymentQueryHandler.cs
@@ -1,0 +1,27 @@
+using AutoMapper;
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Payment;
+using lawyer.api.appointment.application.DTO;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Payment.GetAll;
+
+public class GetAllPaymentQueryHandler : IRequestHandler<GetAllPaymentQuery, List<PaymentDto>>
+{
+    private readonly IPaymentQueryRepository _query;
+    private readonly IMapper _mapper;
+
+    public GetAllPaymentQueryHandler(
+        IMapper mapper,
+        IPaymentQueryRepository query)
+    {
+        _mapper = mapper;
+        _query = query;
+    }
+
+    public async Task<List<PaymentDto>> Handle(GetAllPaymentQuery request, CancellationToken cancellationToken)
+    {
+        var entities = await _query.GetAllAsync();
+        return _mapper.Map<List<PaymentDto>>(entities);
+    }
+}
+

--- a/lawyer.api.appointment.application/UseCases/Payment/GetById/GetByIdPaymentQuery.cs
+++ b/lawyer.api.appointment.application/UseCases/Payment/GetById/GetByIdPaymentQuery.cs
@@ -1,0 +1,15 @@
+using lawyer.api.appointment.application.DTO;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Payment.GetById;
+
+public class GetByIdPaymentQuery : IRequest<PaymentDto>
+{
+    public GetByIdPaymentQuery(Guid id)
+    {
+        Id = id;
+    }
+
+    public Guid Id { get; }
+}
+

--- a/lawyer.api.appointment.application/UseCases/Payment/GetById/GetByIdPaymentQueryHandler.cs
+++ b/lawyer.api.appointment.application/UseCases/Payment/GetById/GetByIdPaymentQueryHandler.cs
@@ -1,0 +1,27 @@
+using AutoMapper;
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Payment;
+using lawyer.api.appointment.application.DTO;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Payment.GetById;
+
+public class GetByIdPaymentQueryHandler : IRequestHandler<GetByIdPaymentQuery, PaymentDto>
+{
+    private readonly IPaymentQueryRepository _query;
+    private readonly IMapper _mapper;
+
+    public GetByIdPaymentQueryHandler(
+        IMapper mapper,
+        IPaymentQueryRepository query)
+    {
+        _mapper = mapper;
+        _query = query;
+    }
+
+    public async Task<PaymentDto> Handle(GetByIdPaymentQuery request, CancellationToken cancellationToken)
+    {
+        var entity = await _query.GetByIdAsync(request.Id);
+        return _mapper.Map<PaymentDto>(entity);
+    }
+}
+

--- a/lawyer.api.appointment.application/UseCases/Payment/Update/UpdatePaymentCommand.cs
+++ b/lawyer.api.appointment.application/UseCases/Payment/Update/UpdatePaymentCommand.cs
@@ -1,0 +1,14 @@
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Payment.Update;
+
+public class UpdatePaymentCommand : IRequest<Guid>
+{
+    public Guid Id { get; set; }
+    public Guid IdUser { get; set; }
+    public Guid IdLawFirm { get; set; }
+    public Guid IdMeeting { get; set; }
+    public decimal Value { get; set; }
+    public string State { get; set; } = string.Empty;
+}
+

--- a/lawyer.api.appointment.application/UseCases/Payment/Update/UpdatePaymentCommandHandler.cs
+++ b/lawyer.api.appointment.application/UseCases/Payment/Update/UpdatePaymentCommandHandler.cs
@@ -1,0 +1,35 @@
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Payment;
+using MediatR;
+
+namespace lawyer.api.appointment.application.UseCases.Payment.Update;
+
+public class UpdatePaymentCommandHandler : IRequestHandler<UpdatePaymentCommand, Guid>
+{
+    private readonly IPaymentCommandRepository _command;
+    private readonly IPaymentQueryRepository _query;
+
+    public UpdatePaymentCommandHandler(
+        IPaymentCommandRepository command,
+        IPaymentQueryRepository query)
+    {
+        _command = command;
+        _query = query;
+    }
+
+    public async Task<Guid> Handle(UpdatePaymentCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _query.GetByIdAsync(request.Id);
+        if (entity == null) throw new KeyNotFoundException($"The payment with ID {request.Id} does not exist.");
+
+        entity.IdUser = request.IdUser;
+        entity.IdLawFirm = request.IdLawFirm;
+        entity.IdMeeting = request.IdMeeting;
+        entity.Value = request.Value;
+        entity.State = request.State;
+        entity.DateModified = DateTime.UtcNow;
+
+        await _command.UpdateAsync(entity);
+        return entity.Id;
+    }
+}
+

--- a/lawyer.api.appointment.datastore.mssql/DatabaseContext/LawyersContext.cs
+++ b/lawyer.api.appointment.datastore.mssql/DatabaseContext/LawyersContext.cs
@@ -15,6 +15,7 @@ public class LawyersContext : DbContext
     public DbSet<CountryEntity> Countries { get; set; }
     public DbSet<SocialNetworkEntity> SocialNetworks { get; set; }
     public DbSet<MeetingEntity> Meetings { get; set; }
+    public DbSet<PaymentEntity> Payments { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/lawyer.api.appointment.datastore.mssql/Model/MappingProfile/ApplicationMappingProfile.cs
+++ b/lawyer.api.appointment.datastore.mssql/Model/MappingProfile/ApplicationMappingProfile.cs
@@ -13,5 +13,6 @@ public class ApplicationMappingProfile : Profile
         CreateMap<Country, CountryEntity>().ReverseMap();
         CreateMap<SocialNetwork, SocialNetworkEntity>().ReverseMap();
         CreateMap<Meeting, MeetingEntity>().ReverseMap();
+        CreateMap<Payment, PaymentEntity>().ReverseMap();
     }
 }

--- a/lawyer.api.appointment.datastore.mssql/Model/Payment.cs
+++ b/lawyer.api.appointment.datastore.mssql/Model/Payment.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using lawyer.api.appointment.datastore.mssql.Model.Common;
+
+namespace lawyer.api.appointment.datastore.mssql.Model;
+
+[Table("Payments", Schema = "appointments")]
+public class PaymentEntity : EFEntity
+{
+    public Guid IdUser { get; set; }
+    public Guid IdLawFirm { get; set; }
+    public Guid IdMeeting { get; set; }
+    public decimal Value { get; set; }
+    public string State { get; set; } = string.Empty;
+}
+

--- a/lawyer.api.appointment.datastore.mssql/PersistenceServiceRegistration.cs
+++ b/lawyer.api.appointment.datastore.mssql/PersistenceServiceRegistration.cs
@@ -3,6 +3,7 @@ using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.City;
 using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Country;
 using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.SocialNetwork;
 using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Meeting;
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Payment;
 using lawyer.api.appointment.datastore.mssql.DatabaseContext;
 using lawyer.api.appointment.datastore.mssql.Model.MappingProfile;
 using lawyer.api.appointment.datastore.mssql.Repositories.Example;
@@ -10,6 +11,7 @@ using lawyer.api.appointment.datastore.mssql.Repositories.City;
 using lawyer.api.appointment.datastore.mssql.Repositories.Country;
 using lawyer.api.appointment.datastore.mssql.Repositories.SocialNetwork;
 using lawyer.api.appointment.datastore.mssql.Repositories.Meeting;
+using lawyer.api.appointment.datastore.mssql.Repositories.Payment;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,6 +36,8 @@ public static class PersistenceServiceRegistration
         services.AddScoped<ISocialNetworkQueryRepository, SocialNetworkQueryRepository>();
         services.AddScoped<IMeetingCommandRepository, MeetingCommandRepository>();
         services.AddScoped<IMeetingQueryRepository, MeetingQueryRepository>();
+        services.AddScoped<IPaymentCommandRepository, PaymentCommandRepository>();
+        services.AddScoped<IPaymentQueryRepository, PaymentQueryRepository>();
 
         return services;
     }

--- a/lawyer.api.appointment.datastore.mssql/Repositories/Payment/PaymentCommandRepository.cs
+++ b/lawyer.api.appointment.datastore.mssql/Repositories/Payment/PaymentCommandRepository.cs
@@ -1,0 +1,18 @@
+using AutoMapper;
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Payment;
+using lawyer.api.appointment.datastore.mssql.DatabaseContext;
+using lawyer.api.appointment.datastore.mssql.Model;
+using lawyer.api.appointment.datastore.mssql.Repositories.Common;
+
+namespace lawyer.api.appointment.datastore.mssql.Repositories.Payment;
+
+public class PaymentCommandRepository : CommandRepository<domain.Payment, PaymentEntity>, IPaymentCommandRepository
+{
+    private readonly IMapper _mapper;
+
+    public PaymentCommandRepository(LawyersContext dbContext, IMapper mapper) : base(dbContext, mapper)
+    {
+        _mapper = mapper;
+    }
+}
+

--- a/lawyer.api.appointment.datastore.mssql/Repositories/Payment/PaymentQueryRepository.cs
+++ b/lawyer.api.appointment.datastore.mssql/Repositories/Payment/PaymentQueryRepository.cs
@@ -1,0 +1,18 @@
+using AutoMapper;
+using lawyer.api.appointment.application.Contracts.Interfaces.Persistence.Payment;
+using lawyer.api.appointment.datastore.mssql.DatabaseContext;
+using lawyer.api.appointment.datastore.mssql.Model;
+using lawyer.api.appointment.datastore.mssql.Repositories.Common;
+
+namespace lawyer.api.appointment.datastore.mssql.Repositories.Payment;
+
+public class PaymentQueryRepository : QueryRepository<domain.Payment, PaymentEntity>, IPaymentQueryRepository
+{
+    private readonly IMapper _mapper;
+
+    public PaymentQueryRepository(LawyersContext dbContext, IMapper mapper) : base(dbContext, mapper)
+    {
+        _mapper = mapper;
+    }
+}
+

--- a/lawyer.api.appointment.domain/Payment.cs
+++ b/lawyer.api.appointment.domain/Payment.cs
@@ -1,0 +1,13 @@
+using lawyer.api.appointment.domain.Common;
+
+namespace lawyer.api.appointment.domain;
+
+public class Payment : BaseEntity
+{
+    public Guid IdUser { get; set; }
+    public Guid IdLawFirm { get; set; }
+    public Guid IdMeeting { get; set; }
+    public decimal Value { get; set; }
+    public string State { get; set; } = string.Empty;
+}
+

--- a/lawyer.api.appointment.webapi/Controllers/PaymentController.cs
+++ b/lawyer.api.appointment.webapi/Controllers/PaymentController.cs
@@ -1,0 +1,71 @@
+using lawyer.api.appointment.application.DTO;
+using lawyer.api.appointment.application.UseCases.Payment.Create;
+using lawyer.api.appointment.application.UseCases.Payment.Delete;
+using lawyer.api.appointment.application.UseCases.Payment.GetAll;
+using lawyer.api.appointment.application.UseCases.Payment.GetById;
+using lawyer.api.appointment.application.UseCases.Payment.Update;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace lawyer.api.appointment.webapi.Controllers;
+
+[Authorize]
+[ApiController]
+[Route("api/[controller]")]
+public class PaymentController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public PaymentController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<PaymentDto>>> Get()
+    {
+        var entities = await _mediator.Send(new GetAllPaymentQuery());
+        return Ok(entities);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<PaymentDto>> Get(Guid id)
+    {
+        var entity = await _mediator.Send(new GetByIdPaymentQuery(id));
+        return Ok(entity);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(201)]
+    [ProducesResponseType(400)]
+    public async Task<ActionResult> Post([FromBody] CreatePaymentCommand command)
+    {
+        var id = await _mediator.Send(command);
+        var url = Url.Action(nameof(Get), new { id });
+        return Created(url, id);
+    }
+
+    [HttpPut]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(400)]
+    public async Task<ActionResult> Put([FromBody] UpdatePaymentCommand command)
+    {
+        if (command.Id == Guid.Empty)
+            return BadRequest("The provided ID is not valid.");
+
+        var updatedId = await _mediator.Send(command);
+        return Ok(updatedId);
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(404)]
+    public async Task<ActionResult> Delete(Guid id)
+    {
+        var command = new DeletePaymentCommand { Id = id };
+        await _mediator.Send(command);
+        return NoContent();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Payment domain entity with persistence and mapping
- implement Payment CRUD use cases and Web API controller
- register payment repositories and mappings in persistence layer

## Testing
- `dotnet build lawyer.api.appointment.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a74d21f08323a42911ce246386bd